### PR TITLE
Feat/experimetal transpile with swc

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,21 @@
 	},
 	"dependencies": {
 		"@expressots/boost-ts": "1.1.1",
+		"@swc/cli": "0.1.62",
+		"@swc/core": "1.3.80",
+		"@swc/register": "0.1.10",
 		"chalk-animation": "2.0.3",
 		"cli-progress": "3.11.2",
+		"concurrently": "8.2.1",
 		"degit": "2.8.4",
 		"glob": "10.2.6",
 		"inquirer": "8.0.0",
 		"mustache": "4.2.0",
+		"nodemon": "3.0.1",
+		"rimraf": "5.0.1",
 		"ts-node": "10.9.1",
+		"ts-node-dev": "2.0.0",
+		"tsconfig-paths": "4.2.0",
 		"yargs": "17.6.2"
 	},
 	"devDependencies": {
@@ -67,6 +75,7 @@
 		"@types/inquirer": "^9.0.3",
 		"@types/mustache": "^4.2.2",
 		"@types/node": "^18.11.19",
+		"@types/nodemon": "^1.19.2",
 		"@types/yargs": "^17.0.22",
 		"@typescript-eslint/eslint-plugin": "^5.53.0",
 		"@typescript-eslint/parser": "^5.53.0",
@@ -77,8 +86,6 @@
 		"husky": "^8.0.3",
 		"prettier": "^2.8.4",
 		"release-it": "^16.1.5",
-		"rimraf": "^4.1.2",
-		"ts-node-dev": "^2.0.0",
 		"typescript": "^4.9.5",
 		"vite": "^4.4.9",
 		"vitest": "^0.34.4"

--- a/src/@types/command-args.ts
+++ b/src/@types/command-args.ts
@@ -1,0 +1,7 @@
+export interface CommandDevArgs {
+    experimental: boolean;
+}
+
+export interface CommandBuildArgs {
+	experimental: boolean;
+}

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,2 +1,3 @@
 export * from "./config";
 export * from "./template";
+export * from "./command-args";

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,1 +1,2 @@
 export * from "./config";
+export * from "./template";

--- a/src/@types/template.ts
+++ b/src/@types/template.ts
@@ -1,0 +1,10 @@
+export enum TemplateEnum {
+    OPINIONATED = "opinionated",
+    NON_OPINIONATED = "non-opinionated"
+}
+
+export interface Template {
+	name: TemplateEnum;
+	description: string;
+	path: string;
+}

--- a/src/build/cli.ts
+++ b/src/build/cli.ts
@@ -1,0 +1,13 @@
+import { CommandModule } from "yargs";
+import { projectForm } from "./form";
+import { CommandDevArgs } from "../@types";
+
+const buildProject = (): CommandModule<Record<string, never>, CommandDevArgs> => {
+	return {
+		command: "build",
+		describe: "Build project",
+		handler: projectForm,
+	};
+};
+
+export { buildProject };

--- a/src/build/form.ts
+++ b/src/build/form.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import path from "node:path";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { CommandBuildArgs } from "../@types";
+import { printError } from "../utils/cli-ui";
+import { getPlatformCommand } from "../utils/get-platform-command-bin";
+
+const PATH = `${process.env.PATH}${path.delimiter}${path.resolve(__dirname, "../../node_modules/.bin")}`;
+const env = { ...process.env, PATH };
+
+const projectForm = async ({ experimental }: CommandBuildArgs): Promise<void> => {
+	console.time("Build succeed");
+
+	spawnSync("rimraf", ["dist"], { env, stdio: "inherit" });
+
+	if (experimental) {
+		if (!existsSync(".swcrc")) {
+			printError("Experimental features needs .swcrc file", ".swcrc");
+			process.exit(1);
+		}
+
+		const { result } = require("concurrently")([
+			{ name: "types", command: "tsc --noEmit" },
+			{ name: "lint", command: "eslint src/**/*.ts" },
+			{ name: "build", command: "swc src -d dist" },
+		], { raw: true });
+		
+		result
+			.then(() => {
+				console.timeEnd("Build succeed");
+			})
+			.catch(() => {
+				printError("Build failed", "expressots build");
+				process.exit(1);
+			});
+
+		return;
+	}
+
+	spawnSync(getPlatformCommand("tsc"), ["-p", "tsconfig.build.json"], { env, stdio: "inherit" });
+	console.timeEnd("Build succeed");
+};
+
+export { projectForm };

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -1,0 +1,1 @@
+export * from "./cli";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,8 @@ import { hideBin } from "yargs/helpers";
 import { generateProject } from "./generate";
 import { infoProject } from "./info";
 import { createProject } from "./new";
+import { devProject } from "./dev";
+import { buildProject } from "./build";
 
 export const CLI_VERSION = "1.3.4";
 
@@ -15,6 +17,8 @@ yargs(hideBin(process.argv))
 	.command(createProject())
 	.command(generateProject())
 	.command(infoProject())
+	.command(devProject())
+	.command(buildProject())
 	.example("$0 new expressots-demo", "Create interactively")
 	.example("$0 new expressots-demo -d ./", "Create interactively with path")
 	.example("$0 new expressots-demo -p yarn -t opinionated", "Create silently")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ yargs(hideBin(process.argv))
 	)
 	.example(
 		"$0 new expressots-demo -p yarn -t opinionated --experimental",
-		"Create with experimental swc build system"
+		"Create using experimental, not battle-tested, features of ExpressoTS",
 	)
 	.example("$0 generate service user-create", "Scaffold a service")
 	.example("$0 info", "Show CLI details")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,10 @@ yargs(hideBin(process.argv))
 		"$0 new expressots-demo -p yarn -t opinionated -d ./",
 		"Create silently with path",
 	)
+	.example(
+		"$0 new expressots-demo -p yarn -t opinionated --experimental",
+		"Create with experimental swc build system"
+	)
 	.example("$0 generate service user-create", "Scaffold a service")
 	.example("$0 info", "Show CLI details")
 	.demandCommand(1, "You need at least one command before moving on")

--- a/src/dev/cli.ts
+++ b/src/dev/cli.ts
@@ -1,0 +1,13 @@
+import { CommandModule } from "yargs";
+import { projectForm } from "./form";
+import { CommandDevArgs } from "../@types";
+
+const devProject = (): CommandModule<Record<string, never>, CommandDevArgs> => {
+	return {
+		command: "dev",
+		describe: "Run project in development mode",
+		handler: projectForm,
+	};
+};
+
+export { devProject };

--- a/src/dev/form.ts
+++ b/src/dev/form.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import path from "node:path";
+import { existsSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import nodemon from "nodemon";
+import { CommandDevArgs } from "../@types";
+import { printError } from "../utils/cli-ui";
+import { getPlatformCommand } from "../utils/get-platform-command-bin";
+
+const projectForm = async ({ experimental }: CommandDevArgs): Promise<void> => {
+	if (experimental) {
+		if (!existsSync(".swcrc")) {
+			printError("Experimental features needs .swcrc file", ".swcrc");
+			process.exit(1);
+		}
+
+		require('@swc/register');
+
+		function nodemonRestart() {
+			spawn(getPlatformCommand("eslint"), ["src/**/*.ts"], { stdio: "inherit" });
+			spawn(getPlatformCommand("tsc"), ["--noEmit"], { stdio: "inherit" });
+		}
+
+		nodemon({
+			ext: "ts",
+			exec: `node -r ${require.resolve("@swc/register")} src/main.ts`,
+		})
+			.on("start", nodemonRestart)
+			.on("restart", nodemonRestart);
+		
+
+		return;
+	}
+
+	spawnSync(getPlatformCommand("ts-node-dev"), ["src/main.ts"], { stdio: "inherit" });
+};
+
+export { projectForm };

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -1,0 +1,1 @@
+export * from "./cli";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./generate";
 export * from "./utils";
 export * from "./new";
+export * from "./dev";

--- a/src/new/cli.ts
+++ b/src/new/cli.ts
@@ -38,7 +38,7 @@ const createProject = (): CommandModule<CommandModuleArgs, any> => {
 					alias: "d",
 				})
 				.option("experimental", {
-					describe: "Use experimental traspile with swc",
+					describe: "Use experimental, not battle-tested, features of ExpressoTS",
 					type: "boolean",
 					default: false,
 				})
@@ -47,19 +47,8 @@ const createProject = (): CommandModule<CommandModuleArgs, any> => {
 
 			return yargs;
 		},
-		handler: async ({
-			projectName,
-			packageManager,
-			template,
-			directory,
-			experimental,
-		}) => {
-			return await projectForm(projectName, [
-				packageManager,
-				template,
-				directory,
-				experimental,
-			]);
+		handler: async ({ projectName, packageManager, template, directory, experimental }) => {
+			return await projectForm(projectName, [packageManager, template, directory, experimental]);
 		},
 	};
 };

--- a/src/new/cli.ts
+++ b/src/new/cli.ts
@@ -12,7 +12,7 @@ const createProject = (): CommandModule<CommandModuleArgs, any> => {
 	}
 
 	return {
-		command: "new <project-name> [package-manager] [template] [directory]",
+		command: "new <project-name> [package-manager] [template] [directory] [experimental]",
 		describe: "Create a new project",
 		builder: (yargs: Argv): Argv => {
 			yargs
@@ -37,6 +37,11 @@ const createProject = (): CommandModule<CommandModuleArgs, any> => {
 					type: "string",
 					alias: "d",
 				})
+				.option("experimental", {
+					describe: "Use experimental traspile with swc",
+					type: "boolean",
+					default: false,
+				})
 				.implies("package-manager", "template")
 				.implies("template", "package-manager");
 
@@ -47,11 +52,13 @@ const createProject = (): CommandModule<CommandModuleArgs, any> => {
 			packageManager,
 			template,
 			directory,
+			experimental,
 		}) => {
 			return await projectForm(projectName, [
 				packageManager,
 				template,
 				directory,
+				experimental,
 			]);
 		},
 	};

--- a/src/new/form.ts
+++ b/src/new/form.ts
@@ -215,7 +215,7 @@ const projectForm = async (projectName: string, args: any[]): Promise<void> => {
 
 		try  {
 			const emitter = experimental
-				? degit(`joaoneto/expressots-opinionated-experimental#${templates[template]}`)
+				? degit(`expressots/expressots/templates/experimental/${templates[template]}`)
 				: degit(`expressots/expressots/templates/${templates[template]}`);
 	
 			await emitter.clone(answer.name);

--- a/src/new/form.ts
+++ b/src/new/form.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { centerText } from "../utils/center-text";
 import { printError } from "../utils/cli-ui";
 import { TemplateEnum } from "../@types";
+import { getPlatformCommand } from "../utils/get-platform-command-bin";
 import templateList from "../templates-list";
 
 async function packageManagerInstall({
@@ -20,10 +21,7 @@ async function packageManagerInstall({
 	progressBar: SingleBar;
 }) {
 	return new Promise((resolve, reject) => {
-		const isWindows: boolean = process.platform === "win32";
-		const command: string = isWindows
-			? `${packageManager}.cmd`
-			: packageManager;
+		const command = getPlatformCommand(packageManager);
 
 		const installProcess = spawn(command, ["install"], {
 			cwd: directory,

--- a/src/new/form.ts
+++ b/src/new/form.ts
@@ -214,6 +214,7 @@ const projectForm = async (projectName: string, args: any[]): Promise<void> => {
 		const [_, template] = answer.template.match(/(.*) ::/) as Array<string>;
 
 		try  {
+			// @todo: new templates, see expressots/expressots PR #79
 			const emitter = experimental
 				? degit(`expressots/expressots/templates/experimental/${templates[template]}`)
 				: degit(`expressots/expressots/templates/${templates[template]}`);

--- a/src/templates-list.ts
+++ b/src/templates-list.ts
@@ -1,0 +1,30 @@
+import { TemplateEnum, Template } from "./@types";
+
+const stable: Template[] = [
+	{
+		name: TemplateEnum.OPINIONATED,
+		description: "Non-Opinionated :: A simple ExpressoTS project.",
+		path: "expressots/expressots/templates/non_opinionated",
+	},
+	{
+		name: TemplateEnum.NON_OPINIONATED,
+		description: "Opinionated :: A complete ExpressoTS project with an opinionated structure and features.",
+		path: "expressots/expressots/templates/opinionated",
+	},
+];
+
+const experimental: Template[] = [
+	{
+		name: TemplateEnum.OPINIONATED,
+		description: "Non-Opinionated :: EXPERIMENTAL BUILD - A simple ExpressoTS project.",
+		path: "expressots/expressots/templates/experimental/non_opinionated",
+	},
+	{
+		name: TemplateEnum.NON_OPINIONATED,
+		description:
+			"Opinionated :: EXPERIMENTAL BUILD - A complete ExpressoTS project with an opinionated structure and features.",
+		path: "expressots/expressots/templates/experimental/opinionated",
+	},
+];
+
+export default { stable, experimental };

--- a/src/utils/get-platform-command-bin.ts
+++ b/src/utils/get-platform-command-bin.ts
@@ -1,0 +1,6 @@
+function getPlatformCommand(binName: string) {
+    const isWindows = process.platform === "win32";
+    return isWindows ? `${binName}.cmd` : binName;
+}
+
+export { getPlatformCommand };


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [ ] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## What is the new behavior?

Describe the new behavior or link to a relevant issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Added experimental flag for templates (see: https://github.com/expressots/expressots-cli/pull/17)

An interactive stdout example:
![image](https://github.com/expressots/expressots-cli/assets/547989/36c8fc45-ae04-4073-afc7-ae2b69913af7)


Added cli commands:

This pull request moves the dependencies that used to be in the templates to the CLI, making it essential for the build.
This change simplifies the installation and maintenance of the templates, as they no longer need to have the same dependencies as the CLI. It also allows the CLI to have more control over the build process and use different tools for different tasks.

The pull request adds new dependencies to the expressots-cli package.json file:

- @swc/cli
- @swc/core
- @swc/register
- concurrently
- nodemon
- rimraf
- ts-node-dev
- tsconfig-paths

It also adds a new dev dependency:

- @types/nodemon

The new dependencies can be removed from the templates.

The pull request also adds new commands to the expressots-cli bin file:

- `expressots dev`: uses `ts-node-dev` to start the server and watch for changes in the `./src` directory and reload, showing type errors.
- `expressots dev --experimental`: uses `nodemon` in conjunction with `tsc` and `eslint` respectively to start the server and watch for changes in the `./src` directory and reload and in parallel validate the typing and code style, showing errors.

- `expressots build`: uses `tsc` that look for `tsconfig.build.json` to transpile a hole project in dist
- `expressots build --experimental`: uses `concurrently` to start types, lint and build (with swc) in parallel, and if one of these tasks fail, the process exit code is an error


Any other information that is important to this PR.
