### PR TITLE
Reorder project template choices to favor 'Opinionated'

### DIFF
--- a/src/new/cli.ts
+++ b/src/new/cli.ts
@@ -23,7 +23,7 @@ const createProject = (): CommandModule<CommandModuleArgs, any> => {
 				.option("template", {
 					describe: "The project template to use",
 					type: "string",
-					choices: ["non-opinionated", "opinionated"],
+					choices: ["opinionated", "non-opinionated"],
 					alias: "t",
 				})
 				.option("package-manager", {

--- a/src/new/form.ts
+++ b/src/new/form.ts
@@ -145,8 +145,8 @@ const projectForm = async (projectName: string, args: any[]): Promise<void> => {
 				name: "template",
 				message: "Select a template",
 				choices: [
-					"Non-Opinionated :: A simple ExpressoTS project.",
 					"Opinionated :: A complete ExpressoTS project with an opinionated structure and features.",
+					"Non-Opinionated :: A simple ExpressoTS project.",
 				],
 			},
 			{


### PR DESCRIPTION
# Change Template Order

This PR reorders the template choices presented during project initialization, placing the 'Opinionated' template first.

## Rationale

The 'Opinionated' template offers a more complete and structured starting point for projects, which we want to encourage users to adopt. By listing it first, we align with common UX practices where the preferred or recommended option is listed at the top.

## Changes

- Reordered the `choices` array for the template selection in `cli.ts` and `form.ts` so that 'Opinionated' is now the first option.

Please review the changes and merge them if everything is in order. I believe this small change will have a positive impact on our user's project initialization experience.