### PR TITLE
fix(security): bump undici to 7.28.0 and js-yaml to 3.15.0 (Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,9 +2063,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2813,25 +2813,6 @@
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=18"
@@ -9539,9 +9520,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/release-it": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.0.tgz",
-      "integrity": "sha512-9ZTk9ripgctC6VTqH+P54KuboK29A5mG/I3tFfS5hnoAnkwtFFAMHRidYz93ylrW995vF50Ny1aOGJiyRmEN7w==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
+      "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
       "dev": true,
       "funding": [
         {
@@ -9574,7 +9555,7 @@
         "proxy-agent": "7.0.0",
         "semver": "7.7.4",
         "tinyglobby": "0.2.15",
-        "undici": "7.24.5",
+        "undici": "7.28.0",
         "url-join": "5.0.0",
         "wildcard-match": "5.1.4",
         "yargs-parser": "22.0.0"
@@ -9803,9 +9784,9 @@
       }
     },
     "node_modules/release-it/node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2818,6 +2818,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@release-it/conventional-changelog/node_modules/semver": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` to patch two transitive dependencies:
  - `undici` `7.24.5` -> `7.28.0` (via `release-it`) - clears 2 high + moderate/low undici GHSA advisories.
  - `js-yaml` `3.14.2` -> `3.15.0` (nested via `@istanbuljs/load-nyc-config`) - clears the moderate quadratic-complexity DoS advisory (GHSA-h67p-54hq-rp68).
- `npm audit` now reports **0 vulnerabilities**.

## Changes
- `package-lock.json` only (no manifest / no runtime dependency changes).

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (52 suites, 522 tests)
- [x] `npm audit` reports 0 vulnerabilities
- [ ] CI green on PR (clean `npm ci` install against updated lockfile)